### PR TITLE
User Stories 22 + 23

### DIFF
--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -6,5 +6,6 @@ class Admin::SheltersController < ApplicationController
 
   def show
     @shelter_details = Shelter.get_details(params[:id])
+    @shelter = Shelter.find(params[:id])
   end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -43,4 +43,12 @@ class Shelter < ApplicationRecord
   def shelter_pets_filtered_by_age(age_filter)
     adoptable_pets.where('age >= ?', age_filter)
   end
+
+  def pets_avg_age
+    adoptable_pets.average(:age).to_i
+  end
+
+  def adoptable_pet_count
+    adoptable_pets.count
+  end
 end

--- a/app/views/admin/shelters/show.html.erb
+++ b/app/views/admin/shelters/show.html.erb
@@ -2,3 +2,12 @@
 
 <p>Name: <%= @shelter_details[0] %></p>
 <p>Address: <%= @shelter_details[1] %></p>
+
+<h2>Pet Statistics</h2>
+
+<% if @shelter.adoptable_pet_count == 0 %>
+  <p>No adoptable pets are available at this time.</p>
+<% else %>
+  <p>Number of Adoptable Pets: <%= @shelter.adoptable_pet_count%>
+  <p>Average Age of Adoptable Pets: <%= @shelter.pets_avg_age%> years</p>
+<% end %>

--- a/spec/features/admin/shelters/show_spec.rb
+++ b/spec/features/admin/shelters/show_spec.rb
@@ -27,4 +27,39 @@ RSpec.describe 'admin/shelters show page' do
     expect(page).to have_content(shelter_2.name)
     expect(page).to have_content(shelter_2.city)
   end
+
+  it 'should have a section for statistics with the average age of all adoptable pets for that shelter' do
+    visit "/admin/shelters/#{shelter_1.id}"
+
+    expect(page).to have_content("Pet Statistics")
+    expect(page).to have_content("Average Age of Adoptable Pets: 4 years")
+
+    visit "/admin/shelters/#{shelter_2.id}"
+
+    expect(page).to have_content("Pet Statistics")
+    expect(page).to have_content("Average Age of Adoptable Pets: 8 years")
+
+    visit "/admin/shelters/#{shelter_3.id}"
+
+    expect(page).to have_content("Pet Statistics")
+    expect(page).to have_content("No adoptable pets are available at this time.")
+  end
+
+  it 'should have a section for statistics with the number of pets at the given shelter that are adoptable' do
+    visit "/admin/shelters/#{shelter_1.id}"
+
+    expect(page).to have_content("Pet Statistics")
+    expect(page).to have_content("Number of Adoptable Pets: 2")
+
+    visit "/admin/shelters/#{shelter_2.id}"
+
+    expect(page).to have_content("Pet Statistics")
+    expect(page).to have_content("Number of Adoptable Pets: 1")
+
+    visit "/admin/shelters/#{shelter_3.id}"
+
+    expect(page).to have_content("Pet Statistics")
+    expect(page).to have_content("No adoptable pets are available at this time.")
+    expect(page).to_not have_content("Number of Adoptable Pets")
+  end
 end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -90,5 +90,19 @@ RSpec.describe Shelter, type: :model do
         expect(@shelter_1.pet_count).to eq(3)
       end
     end
+
+    describe '.pets_avg_age' do
+      it 'returns the average age of adoptable pets at the given shelter' do
+        expect(@shelter_1.pets_avg_age).to eq(4)
+      end
+    end
+
+    describe '.adoptable_pet_count' do
+      it 'returns the count of adoptable pets at the given shelter' do
+        expect(@shelter_1.adoptable_pet_count).to eq(2)
+        expect(@shelter_2.adoptable_pet_count).to eq(0)
+        expect(@shelter_3.adoptable_pet_count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR completes functionality for User Stories 22 and 23, including displaying a Pet Statistics section on the admin/shelters show pages with the count of adoptable pets and the average age of adoptable pets.

It handles an edge case where there are no adoptable pets at a given shelter with conditional logic in the view to display a message instead of the actual statistics (which would be 0).

